### PR TITLE
Add settings to the bot

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -14,6 +14,7 @@ const nicknameCommands = require('./commands/discordNames');
 const command_news = require('./commands/news');
 const safeEval = require('./commands/highlySafeEval');
 const command_options = require('./commands/options');
+const optionsApp = require('./lib/options').express;
 
 const BrowserExtensionAPI = require('./lib/browser-extension.js')
 
@@ -32,7 +33,7 @@ for(let key of keys){
   });
 
   app.use("/extension", BrowserExtensionAPI.app);
-
+  app.use("/options", optionsApp);
   app.listen(process.env.PORT, function(){
       console.log(`Express listening on ${process.env.PORT}`)
   });

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -2,7 +2,7 @@ const Discord = require("discord.js");
 const client = new Discord.Client();
 const express = require('express');
 const prefix = "!";
-let nsfw = ["pornhub.com/", "rule34.xxx/", "xhamster.com/"]
+let nsfw = ["pornhub.com/", "rule34.xxx/", "xhamster.com/"];
 
 // IMPORT COMMANDS HERE
 const minecraftServerCommands = require('./commands/server');
@@ -16,142 +16,144 @@ const safeEval = require('./commands/highlySafeEval');
 const command_options = require('./commands/options');
 const optionsApp = require('./lib/options').express;
 
-const BrowserExtensionAPI = require('./lib/browser-extension.js')
+const BrowserExtensionAPI = require('./lib/browser-extension.js');
 
 
-let keys = process.env.BROWSER_API_KEYS.split(" ")
-for(let key of keys){
+let keys = process.env.BROWSER_API_KEYS.split(" ");
+for (let key of keys) {
   BrowserExtensionAPI.addApiKey(key); // Here
 }
 
 
 // region express
-  var app = express();
+var app = express();
 
-  app.get('/ping', function (req, res) {
-      res.send('I am running!');
-  });
-  /** Disable caching to make sure updates to the code show up in the browser*/
-  app.use("/", (req, res, next) => {
-    res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
-    res.header('Expires', '-1');
-    res.header('Pragma', 'no-cache');
-    next();
-  });
-  app.use("/static", express.static('./bot/static_html'));
-  app.use("/extension", BrowserExtensionAPI.app);
-  app.use("/options", optionsApp);
-  app.listen(process.env.PORT, function(){
-      console.log(`Express listening on ${process.env.PORT}`)
-  });
+app.get('/ping', function (req, res) {
+  res.send('I am running!');
+});
+/** Disable caching to make sure updates to the code show up in the browser*/
+app.use("/", (req, res, next) => {
+  res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
+  res.header('Expires', '-1');
+  res.header('Pragma', 'no-cache');
+  next();
+});
+app.use("/static", express.static('./bot/static_html'));
+app.use("/extension", BrowserExtensionAPI.app);
+app.use("/options", optionsApp);
+app.listen(process.env.PORT, function () {
+  console.log(`Express listening on ${process.env.PORT}`)
+});
 // endregion express
 
 
 // region discord
-  client.on("ready", () => {
-      console.log(`Logged in as ${client.user.tag}`);
-  });
+client.on("ready", () => {
+  console.log(`Logged in as ${client.user.tag}`);
+});
 
-  client.on("message", async (msg) => {
-      // Ignore the bot's own messages
-      if (msg.author.bot) return;
+client.on("message", async (msg) => {
+  // Ignore the bot's own messages
+  if (msg.author.bot) return;
 
-      // Instaban any users who post NSFW
-      let msgContainsNSFW = nsfw.some(word => msg.content.toLowerCase().includes(word));
-      if (msg.author.bannable && msgContainsNSFW) {
-          msg.delete();
-          msg.guild.ban(msg.author);
-          return;
-      }
+  // Instaban any users who post NSFW
+  let msgContainsNSFW = nsfw.some(word => msg.content.toLowerCase().includes(word));
+  if (msg.author.bannable && msgContainsNSFW) {
+    msg.delete();
+    msg.guild.ban(msg.author);
+    return;
+  }
 
-      // Ignore any messages that don't start with the prefix
-      if (msg.content.indexOf(prefix) !== 0) return;
+  // Ignore any messages that don't start with the prefix
+  if (msg.content.indexOf(prefix) !== 0) return;
 
-      // Separate the message into command and arguments parts
-      const args = msg.content.slice(prefix.length).trim().split(/ +/g);
-      const command = args.shift().toLowerCase();
+  // Separate the message into command and arguments parts
+  const args = msg.content.slice(prefix.length).trim().split(/ +/g);
+  const command = args.shift().toLowerCase();
 
-      // Available commands
-      const commands = {
-          "userid": (msg) => { msg.channel.send(msg.author.id);},
-          "server": minecraftServerCommands.serverStatus,
-          "phistory": command_playerMcNameHistory,
-          "vote": command_voteLinks,
+  // Available commands
+  const commands = {
+    "userid": (msg) => {
+      msg.channel.send(msg.author.id);
+    },
+    "server": minecraftServerCommands.serverStatus,
+    "phistory": command_playerMcNameHistory,
+    "vote": command_voteLinks,
 
-          "options": command_options,
-          "botping" : selfCommands.ping,
-          "leave": selfCommands.leave,
-          "eval": safeEval,
+    "options": command_options,
+    "botping": selfCommands.ping,
+    "leave": selfCommands.leave,
+    "eval": safeEval,
 
-          "ban": moderationCommands.banPlayer,
-          "kick": moderationCommands.kickPlayer,
-          "warn": moderationCommands.warnPlayer,
-          "view-warns": moderationCommands.showWarns,
-          "delwarn": moderationCommands.removeWarn,
-          "delallwarns": moderationCommands.removeAllWarns,
+    "ban": moderationCommands.banPlayer,
+    "kick": moderationCommands.kickPlayer,
+    "warn": moderationCommands.warnPlayer,
+    "view-warns": moderationCommands.showWarns,
+    "delwarn": moderationCommands.removeWarn,
+    "delallwarns": moderationCommands.removeAllWarns,
 
-          "setname": nicknameCommands.setName,
-          "name": nicknameCommands.getName,
+    "setname": nicknameCommands.setName,
+    "name": nicknameCommands.getName,
 
-          "news": command_news,
-          "restarttime": minecraftServerCommands.restartTime,
-        
-          // ADD COMMANDS HERE
-        
-          "listcommands": (msg) => msg.channel.send(`\`\`\`${Object.keys(commands).join("\n")}\`\`\``),
-          "help": (msg) => {
-              msg.channel.send({
-                  "embed": {
-                      "color": 1234643,
-                      "author": {
-                          "name": "Help Menu"
-                      },
-                      "fields": [
-                          {
-                              "name": "Server Commands",
-                              "value":
-                              "**server** - gives current info about the server.\n" +
-                              "**phistory <name>** - lists every name a player has used\n" +
-                              "**news** - gets the most recent post from news and announcements\n" +
-                              "**vote** - gives all voting links\n" +
-                              "**name <@user>** - views the users set ingame name\n" +
-                              "**setname** - sets the users ingame name"
-                          },
-                          {
-                          
-                              "name": "Bot Commands",
-                              "value":
-                              "**botping** - gives the current ping of the bot\n" +
-                              "**leave <@user>** - If @user is the bot itself, leaves the server\n" +
-                              "**help** - Shows this help page\n" +
-                              "**listcommands** - Lists all the commands that are registered, useful for debugging if the **help** text is out of date",
-                          },
-                          {
-                              "name": "Moderation Commands ",
-                              "value":
-                              "**kick <id>** - kicks a user from the discord\n" +
-                              "**ban <id>** - bans a user from the discord\n" +
-                              "**warn <@user>** - warns the mentioned user\n" +
-                              "**view-warns <@user>** - views the mentioned user's warnings\n" +
-                              "**delwarn <@user> <warn number>** - deletes the specified warning from the mentioned user\n" +
-                              "**delallwarns** - deletes all warns for the mentioned user"
-                          }
-                      ]
-                  }
-              })
-          }
-      };
+    "news": command_news,
+    "restarttime": minecraftServerCommands.restartTime,
 
-      // If the command is not in the list, give an error message
-      // if it is, run it
-      let handler = commands[command];
-      if(handler === undefined) {
-          return;
-      }
-      handler(msg, args, command, client);
+    // ADD COMMANDS HERE
+
+    "listcommands": (msg) => msg.channel.send(`\`\`\`${Object.keys(commands).join("\n")}\`\`\``),
+    "help": (msg) => {
+      msg.channel.send({
+        "embed": {
+          "color": 1234643,
+          "author": {
+            "name": "Help Menu"
+          },
+          "fields": [
+            {
+              "name": "Server Commands",
+              "value":
+                "**server** - gives current info about the server.\n" +
+                "**phistory <name>** - lists every name a player has used\n" +
+                "**news** - gets the most recent post from news and announcements\n" +
+                "**vote** - gives all voting links\n" +
+                "**name <@user>** - views the users set ingame name\n" +
+                "**setname** - sets the users ingame name"
+            },
+            {
+
+              "name": "Bot Commands",
+              "value":
+                "**botping** - gives the current ping of the bot\n" +
+                "**leave <@user>** - If @user is the bot itself, leaves the server\n" +
+                "**help** - Shows this help page\n" +
+                "**listcommands** - Lists all the commands that are registered, useful for debugging if the **help** text is out of date",
+            },
+            {
+              "name": "Moderation Commands ",
+              "value":
+                "**kick <id>** - kicks a user from the discord\n" +
+                "**ban <id>** - bans a user from the discord\n" +
+                "**warn <@user>** - warns the mentioned user\n" +
+                "**view-warns <@user>** - views the mentioned user's warnings\n" +
+                "**delwarn <@user> <warn number>** - deletes the specified warning from the mentioned user\n" +
+                "**delallwarns** - deletes all warns for the mentioned user"
+            }
+          ]
+        }
+      })
+    }
+  };
+
+  // If the command is not in the list, give an error message
+  // if it is, run it
+  let handler = commands[command];
+  if (handler === undefined) {
+    return;
+  }
+  handler(msg, args, command, client);
 
 
-  });
+});
 // endregion discord
 
 client.login(process.env.DISCORD_API_TOKEN);

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -31,7 +31,14 @@ for(let key of keys){
   app.get('/ping', function (req, res) {
       res.send('I am running!');
   });
-
+  /** Disable caching to make sure updates to the code show up in the browser*/
+  app.use("/", (req, res, next) => {
+    res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
+    res.header('Expires', '-1');
+    res.header('Pragma', 'no-cache');
+    next();
+  });
+  app.use("/static", express.static('./bot/static_html'));
   app.use("/extension", BrowserExtensionAPI.app);
   app.use("/options", optionsApp);
   app.listen(process.env.PORT, function(){

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -13,7 +13,7 @@ const moderationCommands = require('./commands/discordModeration');
 const nicknameCommands = require('./commands/discordNames');
 const command_news = require('./commands/news');
 const safeEval = require('./commands/highlySafeEval');
-
+const command_options = require('./commands/options');
 
 const BrowserExtensionAPI = require('./lib/browser-extension.js')
 
@@ -70,6 +70,7 @@ for(let key of keys){
           "phistory": command_playerMcNameHistory,
           "vote": command_voteLinks,
 
+          "options": command_options,
           "botping" : selfCommands.ping,
           "leave": selfCommands.leave,
           "eval": safeEval,

--- a/bot/commands/discordModeration.js
+++ b/bot/commands/discordModeration.js
@@ -3,179 +3,178 @@ const EnmapLevel = require('enmap-level');
 const tableSource = new EnmapLevel({name: "Warns"});
 const myTable = new Enmap({provider: tableSource});
 
-async function banPlayer(msg, args, command, client){
-    let subject;
-    try {
-        subject = await msg.guild.fetchMember(args[0])
-    } catch (err) {
-        msg.channel.send("That user can not be found");
-        return;
-    }
+async function banPlayer(msg, args, command, client) {
+  let subject;
+  try {
+    subject = await msg.guild.fetchMember(args[0])
+  } catch (err) {
+    msg.channel.send("That user can not be found");
+    return;
+  }
 
 
-    let callerHasBanPerms = msg.member.hasPermission('BAN_MEMBERS');
-    let subjectIsBannable = subject.bannable;
-    let callerHasHigherRank = msg.member.highestRole.comparePositionTo(subject.highestRole) > 0;
+  let callerHasBanPerms = msg.member.hasPermission('BAN_MEMBERS');
+  let subjectIsBannable = subject.bannable;
+  let callerHasHigherRank = msg.member.highestRole.comparePositionTo(subject.highestRole) > 0;
 
-    if (!(callerHasBanPerms && subjectIsBannable && callerHasHigherRank)) {
-        msg.channel.send("Someone doesn't have enough permissions. :thinking:");
-        return
-    }
-    msg.guild.ban(subject);
-    msg.channel.send(`I have banned ${subject.displayName}.`);
+  if (!(callerHasBanPerms && subjectIsBannable && callerHasHigherRank)) {
+    msg.channel.send("Someone doesn't have enough permissions. :thinking:");
+    return
+  }
+  msg.guild.ban(subject);
+  msg.channel.send(`I have banned ${subject.displayName}.`);
 }
 
-async function kickPlayer(msg, args, command, client){
-    let subject;
-    try {
-        subject = await msg.guild.fetchMember(args[0])
-    } catch (err) {
-        msg.channel.send("That user can not be found.");
-        return;
-    }
+async function kickPlayer(msg, args, command, client) {
+  let subject;
+  try {
+    subject = await msg.guild.fetchMember(args[0])
+  } catch (err) {
+    msg.channel.send("That user can not be found.");
+    return;
+  }
 
-    let callerIsHigherRank = msg.member.highestRole.comparePositionTo(subject.highestRole) > 0;
-    let callerHasKickPerms = msg.member.hasPermission('KICK_MEMBERS');
-    let subjectIsKickable = subject.kickable;
-    if (callerHasKickPerms && callerIsHigherRank && subjectIsKickable) {
-        subject.kick();
-        msg.channel.send(`I have kicked ${subject.displayName}.`);
-    } else {
-        msg.channel.send("Someone doesn't have enough permissions .:thinking:");
-    }
+  let callerIsHigherRank = msg.member.highestRole.comparePositionTo(subject.highestRole) > 0;
+  let callerHasKickPerms = msg.member.hasPermission('KICK_MEMBERS');
+  let subjectIsKickable = subject.kickable;
+  if (callerHasKickPerms && callerIsHigherRank && subjectIsKickable) {
+    subject.kick();
+    msg.channel.send(`I have kicked ${subject.displayName}.`);
+  } else {
+    msg.channel.send("Someone doesn't have enough permissions .:thinking:");
+  }
 }
 
-async function warnPlayer(msg, args, command, client){
-    if (msg.mentions.users.first() === undefined) {
-        msg.channel.send("Please mention a user to warn them.");
-        return;
-    }
+async function warnPlayer(msg, args, command, client) {
+  if (msg.mentions.users.first() === undefined) {
+    msg.channel.send("Please mention a user to warn them.");
+    return;
+  }
 
-    let subject = await msg.guild.fetchMember(msg.mentions.users.first());
-    let warnContent = args.slice(1).join(" ");
-    if (warnContent.length === 0) {
-        msg.channel.send("Please insert a reason for the warn.");
-        return;
-    }
+  let subject = await msg.guild.fetchMember(msg.mentions.users.first());
+  let warnContent = args.slice(1).join(" ");
+  if (warnContent.length === 0) {
+    msg.channel.send("Please insert a reason for the warn.");
+    return;
+  }
 
-    let callerHasKickPerms = msg.member.hasPermission('KICK_MEMBERS');
-    let callerIsHigherRank = msg.member.highestRole.comparePositionTo(subject.highestRole) > 0;
-    if (!(callerHasKickPerms && callerIsHigherRank)) {
-        msg.channel.send("Someone doesn't have enough permissions. :thinking:");
-        return;
-    }
+  let callerHasKickPerms = msg.member.hasPermission('KICK_MEMBERS');
+  let callerIsHigherRank = msg.member.highestRole.comparePositionTo(subject.highestRole) > 0;
+  if (!(callerHasKickPerms && callerIsHigherRank)) {
+    msg.channel.send("Someone doesn't have enough permissions. :thinking:");
+    return;
+  }
 
-    let subjectId = msg.mentions.users.first().id;
-    if (!myTable.has(subjectId)) {
-        myTable.set(subjectId, [warnContent]);
-        msg.channel.send(`<@${subjectId}> has been warned for \`${warnContent}\``)
-    } else if (myTable.has(subjectId)) {
-        myTable.push(subjectId, warnContent, true);
-        msg.channel.send(`<@${subjectId}> has been warned for \`${warnContent}\``)
-    }
+  let subjectId = msg.mentions.users.first().id;
+  if (!myTable.has(subjectId)) {
+    myTable.set(subjectId, [warnContent]);
+    msg.channel.send(`<@${subjectId}> has been warned for \`${warnContent}\``)
+  } else if (myTable.has(subjectId)) {
+    myTable.push(subjectId, warnContent, true);
+    msg.channel.send(`<@${subjectId}> has been warned for \`${warnContent}\``)
+  }
 }
 
-async function showWarns(msg, args, command, client){
-    if (msg.mentions.users.first() === undefined) {
-        msg.channel.send("Please mention a user to view their warnings.");
-        return;
-    }
+async function showWarns(msg, args, command, client) {
+  if (msg.mentions.users.first() === undefined) {
+    msg.channel.send("Please mention a user to view their warnings.");
+    return;
+  }
 
-    let argMember = await msg.guild.fetchMember(msg.mentions.users.first());
-    if (!msg.member.hasPermission('KICK_MEMBERS')) {
-        msg.channel.send("Someone doesn't have enough permissions. :thinking:")
-        return;
-    }
-    let subjectId = msg.mentions.users.first().id;
-    if (!myTable.has(subjectId)) {
-        msg.channel.send(`<@${subjectId}> doesn't have any warnings. Good job!`)
-        return;
-    }
+  if (!msg.member.hasPermission('KICK_MEMBERS')) {
+    msg.channel.send("Someone doesn't have enough permissions. :thinking:");
+    return;
+  }
+  let subjectId = msg.mentions.users.first().id;
+  if (!myTable.has(subjectId)) {
+    msg.channel.send(`<@${subjectId}> doesn't have any warnings. Good job!`);
+    return;
+  }
 
-    let listWarns = myTable.get(subjectId).reduce((str, el, i) => `${str}**[${i + 1}]** ${el}\n`, '\n')
-    msg.channel.send({
-        "embed": {
-            "description": `<@${subjectId}>'s warnings`,
-            "color": 1234643,
-            "fields": [
-                {
-                    "name": `${myTable.get(subjectId).length} warnings`,
-                    "value": listWarns
-                }
-            ]
+  let listWarns = myTable.get(subjectId).reduce((str, el, i) => `${str}**[${i + 1}]** ${el}\n`, '\n');
+  msg.channel.send({
+    "embed": {
+      "description": `<@${subjectId}>'s warnings`,
+      "color": 1234643,
+      "fields": [
+        {
+          "name": `${myTable.get(subjectId).length} warnings`,
+          "value": listWarns
         }
-    })
+      ]
+    }
+  })
 }
 
-function removeWarn(msg, args, command, client){
-    let subject = msg.mentions.users.first();
-    if (subject === undefined) {
-        msg.channel.send("Please mention a user to delete a warning for.");
-        return;
-    }
-    if (!msg.member.hasPermission('KICK_MEMBERS')) {
-        msg.channel.send("Someone doesn't have enough permissions. :thinking:");
-        return;
-    }
-    if (!myTable.has(subject.id)) {
-        msg.channel.send(`<@${subject.id}> doesn't have any warnings that I can delete. Good job!`);
-        return;
-    }
+function removeWarn(msg, args, command, client) {
+  let subject = msg.mentions.users.first();
+  if (subject === undefined) {
+    msg.channel.send("Please mention a user to delete a warning for.");
+    return;
+  }
+  if (!msg.member.hasPermission('KICK_MEMBERS')) {
+    msg.channel.send("Someone doesn't have enough permissions. :thinking:");
+    return;
+  }
+  if (!myTable.has(subject.id)) {
+    msg.channel.send(`<@${subject.id}> doesn't have any warnings that I can delete. Good job!`);
+    return;
+  }
 
-    let delWarnArray = myTable.get(subject.id);
-    let warnNr;
-    for (let arg of args){
-      try{
-        let attempt = Number(arg);
-        if(!isNaN(attempt)){
-          warnNr = attempt;
-          break;
-        }
-      }catch(e){
-        // Ignore arguments that aren't numbers
+  let delWarnArray = myTable.get(subject.id);
+  let warnNr;
+  for (let arg of args) {
+    try {
+      let attempt = Number(arg);
+      if (!isNaN(attempt)) {
+        warnNr = attempt;
+        break;
       }
+    } catch (e) {
+      // Ignore arguments that aren't numbers
     }
+  }
 
-    if (warnNr === undefined || warnNr <= 0 || delWarnArray.length < warnNr) {
-        msg.channel.send("Please enter a valid warning to delete.");
-        return;
-    }
+  if (warnNr === undefined || warnNr <= 0 || delWarnArray.length < warnNr) {
+    msg.channel.send("Please enter a valid warning to delete.");
+    return;
+  }
 
 
-    let warnIndex = warnNr - 1;
-    let warns = myTable.get(subject.id);
-    warns.splice(warnIndex, 1);
-    if (0 < warns.length) {
-      myTable.set(subject.id, warns, true);
-    
-    } else {
-      myTable.delete(subject.id)
-    
-    }
+  let warnIndex = warnNr - 1;
+  let warns = myTable.get(subject.id);
+  warns.splice(warnIndex, 1);
+  if (0 < warns.length) {
+    myTable.set(subject.id, warns, true);
 
-    msg.channel.send(`I have successfully deleted warning ${warnNr} from <@${subject.id}>`)
+  } else {
+    myTable.delete(subject.id)
+
+  }
+
+  msg.channel.send(`I have successfully deleted warning ${warnNr} from <@${subject.id}>`)
 }
 
-function removeAllWarns(msg, args, command, client){
-    let subject = msg.mentions.users.first();
+function removeAllWarns(msg, args, command, client) {
+  let subject = msg.mentions.users.first();
 
-    if (subject === undefined) {
-        msg.channel.send("Please mention a user to delete all warnings for.");
-        return;
-    }
-    if (!msg.member.hasPermission('KICK_MEMBERS')) {
-        msg.channel.send("Someone doesn't have enough permissions. :thinking:");
-        return;
-    }
-    let id = subject.id;
-    if (!myTable.has(id)) {
-        msg.channel.send(`<@${id}> doesn't have any warnings that I can delete. Good job!`);
-        return;
-    }
+  if (subject === undefined) {
+    msg.channel.send("Please mention a user to delete all warnings for.");
+    return;
+  }
+  if (!msg.member.hasPermission('KICK_MEMBERS')) {
+    msg.channel.send("Someone doesn't have enough permissions. :thinking:");
+    return;
+  }
+  let id = subject.id;
+  if (!myTable.has(id)) {
+    msg.channel.send(`<@${id}> doesn't have any warnings that I can delete. Good job!`);
+    return;
+  }
 
-    let warns = myTable.get(id);
-    msg.channel.send(`I have successfully deleted all ${warns.length} of <@${id}>'s warnings.`);
-    myTable.delete(id)
+  let warns = myTable.get(id);
+  msg.channel.send(`I have successfully deleted all ${warns.length} of <@${id}>'s warnings.`);
+  myTable.delete(id)
 
 }
 

--- a/bot/commands/discordNames.js
+++ b/bot/commands/discordNames.js
@@ -3,34 +3,34 @@ const EnmapLevel = require('enmap-level');
 const tableSource = new EnmapLevel({name: "Names"});
 const myTable = new Enmap({provider: tableSource});
 
-function setName(msg, args, command, client){
-    let id = msg.author.id;
-    let nickName = args[0];
-    if (nickName === null) {
-        msg.channel.send("Please enter the name you want to set.");
-        return;
-    }
-    myTable.set(id, nickName);
-    msg.channel.send(`I have set your name to ${nickName}`)
+function setName(msg, args, command, client) {
+  let id = msg.author.id;
+  let nickName = args[0];
+  if (nickName === null) {
+    msg.channel.send("Please enter the name you want to set.");
+    return;
+  }
+  myTable.set(id, nickName);
+  msg.channel.send(`I have set your name to ${nickName}`)
 }
 
 function getName(msg, args, command, client) {
-    let subject = msg.mentions.users.first();
+  let subject = msg.mentions.users.first();
 
-    let id = msg.author.id;
+  let id = msg.author.id;
 
-    if (myTable.get(id) === null) {
-        if (subject === undefined) {
-            msg.channel.send("You haven't set your name yet");
-        } else {
-            msg.channel.send("This user hasn't set their name yet");
-        }
-        return;
+  if (myTable.get(id) === null) {
+    if (subject === undefined) {
+      msg.channel.send("You haven't set your name yet");
+    } else {
+      msg.channel.send("This user hasn't set their name yet");
     }
+    return;
+  }
 
-    let name = myTable.get(id);
-    let nick = msg.author.username;
-    msg.channel.send(`${nick}'s name is ${name}`);
+  let name = myTable.get(id);
+  let nick = msg.author.username;
+  msg.channel.send(`${nick}'s name is ${name}`);
 }
 
 module.exports.setName = setName;

--- a/bot/commands/discordSelf.js
+++ b/bot/commands/discordSelf.js
@@ -1,39 +1,39 @@
-
 function ping(msg, args, command, client) {
-    msg.channel.send('Pinging...')
+  msg.channel.send('Pinging...')
     .then(sent => {
-        sent.edit(`:ping_pong: Pong! Took ${sent.createdTimestamp - msg.createdTimestamp}ms`);
+      sent.edit(`:ping_pong: Pong! Took ${sent.createdTimestamp - msg.createdTimestamp}ms`);
     });
 }
+
 function leave(msg, args, command, client) {
-    let callerHasKickPerms = msg.member.hasPermission('KICK_MEMBERS');
-    if(!callerHasKickPerms){
-      msg.channel.send("You can't tell me what to do");
+  let callerHasKickPerms = msg.member.hasPermission('KICK_MEMBERS');
+  if (!callerHasKickPerms) {
+    msg.channel.send("You can't tell me what to do");
+    return;
+  }
+  let mention = msg.mentions.users.first();
+  if (mention === undefined) {
+    let botCount = msg.guild.members.filter(user => user.bot).length;
+    if (botCount > 1) {
+      msg.channel.send("You gotta mention a bot so i know which one uf us has to go");
       return;
     }
-    let mention = msg.mentions.users.first();
-    if(mention === undefined){
-        let botCount = msg.guild.members.filter(user => user.bot).length;
-        if(botCount > 1){
-            msg.channel.send("You gotta mention a bot so i know which one uf us has to go");
-            return;
-        }
-        msg.channel.send("Welp, i'm the only bot here so i'm guessing you meant me - see ya later <3");
-        msg.channel.guild.leave();
-        return;
-    }
+    msg.channel.send("Welp, i'm the only bot here so i'm guessing you meant me - see ya later <3");
+    msg.channel.guild.leave();
+    return;
+  }
 
-    let bot_is_mentioned = client.user.id === mention.id;
-    if(bot_is_mentioned){
-        msg.channel.send("See ya later <3");
-        msg.channel.guild.leave();
-        return;
-    }
-    if(mention.bot){
-        msg.channel.send(`Bye bye ${mention}`);
-        return;
-    }
-    msg.channel.send("That's a regular user - they don't tend to react to commands")
+  let bot_is_mentioned = client.user.id === mention.id;
+  if (bot_is_mentioned) {
+    msg.channel.send("See ya later <3");
+    msg.channel.guild.leave();
+    return;
+  }
+  if (mention.bot) {
+    msg.channel.send(`Bye bye ${mention}`);
+    return;
+  }
+  msg.channel.send("That's a regular user - they don't tend to react to commands")
 
 
 }

--- a/bot/commands/highlySafeEval.js
+++ b/bot/commands/highlySafeEval.js
@@ -1,25 +1,26 @@
 function safeEval(msg, args, command, client) {
   if (msg.author.id !== '236448694172516353') return;
 
-const content = msg.content.split(' ').slice(1).join(' ');
-const result = new Promise((resolve, reject) => resolve(eval(content)));
+  const content = msg.content.split(' ').slice(1).join(' ');
+  const result = new Promise((resolve, reject) => resolve(eval(content)));
 
-return result.then(output => {
- if (typeof output !== 'string') output = require('util').inspect(output, {
- depth: 0
- });
- if (output.includes(client.token)) output = output.replace(client.token, 'Not for your eyes');
- if (output.length > 1990) console.log(output), output = 'Too long to be printed (content got console logged)';
+  return result.then(output => {
+    if (typeof output !== 'string') output = require('util').inspect(output, {
+      depth: 0
+    });
+    if (output.includes(client.token)) output = output.replace(client.token, 'Not for your eyes');
 
- return msg.edit(output, {code: 'js'});
-}).catch(err => {
- console.error(err);
- err = err.toString();
+    if (output.length > 1990) console.log(output), output = 'Too long to be printed (content got console logged)';
 
- if (err.includes(client.token)) err = err.replace(client.token, 'Not for your eyes');
+    return msg.edit(output, {code: 'js'});
+  }).catch(err => {
+    console.error(err);
+    err = err.toString();
 
- return msg.edit(err, {code: 'js'});
-});
+    if (err.includes(client.token)) err = err.replace(client.token, 'Not for your eyes');
+
+    return msg.edit(err, {code: 'js'});
+  });
 }
 
-module.exports = safeEval
+module.exports = safeEval;

--- a/bot/commands/news.js
+++ b/bot/commands/news.js
@@ -13,10 +13,10 @@ function showNews(msg, args, command, client) {
   }
   if (args[0] === "all") {
     let out = "All news on the first page:\n";
-    let index = 1
+    let index = 1;
     for (let post of posts) {
-      out += `\n**[${index}]** ${post.title.replace("\n","")}`;
-      index ++
+      out += `\n**[${index}]** ${post.title.replace("\n", "")}`;
+      index++
     }
     msg.channel.send(out);
     return;
@@ -25,19 +25,19 @@ function showNews(msg, args, command, client) {
     function isNumeric(n) {
       return !isNaN(parseFloat(n)) && isFinite(n);
     }
-    
+
     if (Number.isInteger(args[1])) {
-      msg.channel.send('Please specify which article to display.')
+      msg.channel.send('Please specify which article to display.');
       return;
     }
     let index = Number(args[1]) - 1;
-    if(args[1] < 1 || posts.length < args[1]) {
-      msg.channel.send(`Please specify a valid article to display. There are currently ${posts.length} news articles on the first page.`)
+    if (args[1] < 1 || posts.length < args[1]) {
+      msg.channel.send(`Please specify a valid article to display. There are currently ${posts.length} news articles on the first page.`);
       return;
     }
-    
-    
-    if(isNaN(index)) {
+
+
+    if (isNaN(index)) {
       msg.channel.send(`Please specify a valid article to display. There are currently ${posts.length} news articles on the first page.`)
     }
     var post = posts[index];
@@ -57,27 +57,9 @@ function showNews(msg, args, command, client) {
           "value": post.content
         }]
       }
-    })
+    });
     return;
   }
-  
-  /*msg.channel.send({
-    "embed": {
-      "description": `[${posts[0].title}](${posts[0].link})`,
-      "color": 1234643,
-      "footer": {
-        "text": posts[0].time
-      },
-      "author": {
-        "name": "News and Announcements",
-        "url": "https://www.swancraftmc.com/forum/m/39419318/viewforum/7509935"
-      },
-      "fields": [{
-        "name": posts[0].author,
-        "value": posts[0].content
-      }]
-    }
-  })*/
 }
 
 module.exports = showNews;

--- a/bot/commands/options.js
+++ b/bot/commands/options.js
@@ -1,0 +1,30 @@
+const options = require('../lib/options');
+function optionsCommand(msg, args, command, client){
+    let subcommand = args[0];
+    let namespace = args[1];
+    let name = args[2];
+    let value = args[3];
+    console.log(options);
+    switch(subcommand){
+        case 'list':
+            let message = ["."];
+            for(let key of Object.keys(options.all)){
+                message.push(`**${key}**`);
+                for(let subkey of options(key).list()){
+                    message.push(`${subkey}: ${JSON.stringify(options(key).get(subkey))}`)
+                }
+            }
+            msg.channel.send(message.join("\n"));
+            return;
+
+        case 'set':
+            options(namespace).set(name, JSON.parse(value));
+            msg.channel.send("Option set successfully");
+            return;
+
+        case 'get':
+            msg.channel.send(`Current value is: ${JSON.stringify(options(namespace).get(name))}`);
+            return;
+    }
+}
+module.exports = optionsCommand;

--- a/bot/commands/options.js
+++ b/bot/commands/options.js
@@ -1,34 +1,36 @@
 const options = require('../lib/options');
-function optionsCommand(msg, args, command, client){
-    let subcommand = args[0];
-    let namespace = args[1];
-    let name = args[2];
-    let value = args[3];
-    console.log(options);
-    switch(subcommand){
-        case 'list':
-            let message = ["."];
-            for(let key of options.all()){
-                message.push(`**${key}**`);
-                for(let subkey of options(key).list()){
-                    message.push(`${subkey}: ${JSON.stringify(options(key).get(subkey))}`)
-                }
-            }
-            msg.channel.send(message.join("\n"));
-            return;
 
-        case 'set':
-            try{
-                options(namespace).set(name, JSON.parse(value));
-                msg.channel.send("Option set successfully");
-            } catch (e) {
-                msg.channel.send(`Could not set option: ${e}`);
-            }
-            return;
+function optionsCommand(msg, args, command, client) {
+  let subcommand = args[0];
+  let namespace = args[1];
+  let name = args[2];
+  let value = args[3];
+  console.log(options);
+  switch (subcommand) {
+    case 'list':
+      let message = ["."];
+      for (let key of options.all()) {
+        message.push(`**${key}**`);
+        for (let subkey of options(key).list()) {
+          message.push(`${subkey}: ${JSON.stringify(options(key).get(subkey))}`)
+        }
+      }
+      msg.channel.send(message.join("\n"));
+      return;
 
-        case 'get':
-            msg.channel.send(`Current value is: ${JSON.stringify(options(namespace).get(name))}`);
-            return;
-    }
+    case 'set':
+      try {
+        options(namespace).set(name, JSON.parse(value));
+        msg.channel.send("Option set successfully");
+      } catch (e) {
+        msg.channel.send(`Could not set option: ${e}`);
+      }
+      return;
+
+    case 'get':
+      msg.channel.send(`Current value is: ${JSON.stringify(options(namespace).get(name))}`);
+      return;
+  }
 }
+
 module.exports = optionsCommand;

--- a/bot/commands/options.js
+++ b/bot/commands/options.js
@@ -8,7 +8,7 @@ function optionsCommand(msg, args, command, client){
     switch(subcommand){
         case 'list':
             let message = ["."];
-            for(let key of Object.keys(options.all)){
+            for(let key of options.all()){
                 message.push(`**${key}**`);
                 for(let subkey of options(key).list()){
                     message.push(`${subkey}: ${JSON.stringify(options(key).get(subkey))}`)
@@ -18,8 +18,12 @@ function optionsCommand(msg, args, command, client){
             return;
 
         case 'set':
-            options(namespace).set(name, JSON.parse(value));
-            msg.channel.send("Option set successfully");
+            try{
+                options(namespace).set(name, JSON.parse(value));
+                msg.channel.send("Option set successfully");
+            } catch (e) {
+                msg.channel.send(`Could not set option: ${e}`);
+            }
             return;
 
         case 'get':

--- a/bot/commands/phistory.js
+++ b/bot/commands/phistory.js
@@ -1,24 +1,23 @@
-let BrowserExtensionAPI = require('../lib/browser-extension');
 const snekfetch = require('snekfetch');
 
-async function getMCPlayerHistory(msg, args, command, client){
+async function getMCPlayerHistory(msg, args, command, client) {
   if (args[0] === undefined) {
-    msg.channel.send("Please enter a user to view the name history for.")
+    msg.channel.send("Please enter a user to view the name history for.");
     return
   }
-  console.log("phistory called with args",msg,args,command)
+  console.log("phistory called with args", msg, args, command);
   const res = await snekfetch.get(`https://api.mojang.com/users/profiles/minecraft/${args[0]}`);
-  let id = res.body.id
+  let id = res.body.id;
   const his = await snekfetch.get(`https://api.mojang.com/user/profiles/${id}/names`);
-  let map = his.body.reverse().map(o => o.name + ' : [' + (o.changedToAt === undefined ? 'ORIGINAL NAME' : new Date(o.changedToAt).toDateString()) + ']')
-  let newmap = map.join('\n')
+  let map = his.body.reverse().map(o => o.name + ' : [' + (o.changedToAt === undefined ? 'ORIGINAL NAME' : new Date(o.changedToAt).toDateString()) + ']');
+  let newmap = map.join('\n');
   msg.channel.send({
     "embed": {
       "color": 1234643,
       "fields": [
         {
           "name": `${args[0]}'s name history`,
-          "value": newmap 
+          "value": newmap
         }
       ]
     }

--- a/bot/commands/server.js
+++ b/bot/commands/server.js
@@ -1,98 +1,95 @@
 const ms = require("../lib/minestat");
 const settings = require('../lib/options')('server');
 
-settings.define('showPlayercount','boolean', false);
+settings.define('showPlayercount', 'boolean', false);
 
-var serverStatus_options = {
-    "pcmode": {name:"Show playercount", type: 'bool', value: false}
-};
 async function serverStatus(msg, args, command, client) {
-    let result = await new Promise(resolve => ms.init('198.50.141.83',25565, (a) => resolve(a)));
-    if (!ms.online) {
-        msg.channel.send("Server is offline. Please try again later.");
-        return;
-    }
-    let message = {
-        "embed": {
-            "url": "https://discordapp.com",
-            "color": 1234643,
-            "thumbnail": {
-                "url": "https://api.minetools.eu/favicon/198.50.141.83/25565"
-            },
-            "author": {
-                "name": "SwancraftMC",
-                "url": "https://www.swancraftmc.com/"
-            },
-            "fields": [
-                {
-                    "name": "Server status",
-                    "value": "Online ✓"
-                },
-                {
-                    "name": "Server IP",
-                    "value": "play.swancraftmc.com"
-                },
-                {
-                    "name": "Server version",
-                    "value": ms.version
-                }
-            ]
+  await new Promise(resolve => ms.init('198.50.141.83', 25565, (a) => resolve(a)));
+  if (!ms.online) {
+    msg.channel.send("Server is offline. Please try again later.");
+    return;
+  }
+  let message = {
+    "embed": {
+      "url": "https://discordapp.com",
+      "color": 1234643,
+      "thumbnail": {
+        "url": "https://api.minetools.eu/favicon/198.50.141.83/25565"
+      },
+      "author": {
+        "name": "SwancraftMC",
+        "url": "https://www.swancraftmc.com/"
+      },
+      "fields": [
+        {
+          "name": "Server status",
+          "value": "Online ✓"
+        },
+        {
+          "name": "Server IP",
+          "value": "play.swancraftmc.com"
+        },
+        {
+          "name": "Server version",
+          "value": ms.version
         }
-    };
-    console.log(settings.get("showPlayercount"));
-    if(settings.get('showPlayercount')){
-        message.embed.fields.push({name: "Players online", value:ms.current_players})
+      ]
     }
-    msg.channel.send(message);
+  };
+  if (settings.get('showPlayercount')) {
+    message.embed.fields.push({name: "Players online", value: ms.current_players})
+  }
+  msg.channel.send(message);
 }
 
-function restartTime(msg, args, command, client){
+function restartTime(msg, args, command, client) {
   const now = new Date();
   // A specific restart's time - we can't compare the hours directly because timezones exist
-  let next = new Date(1534809600000); 
-  if(args[0] !== undefined){
+  let next = new Date(1534809600000);
+  if (args[0] !== undefined) {
     next = new Date(args[0]);
   }
   // That same time, but yesterday, there must have been a restart, let's set 'next' to be that restart from yesterday
-  next.setYear(now.getYear()+1900) // add 1900 because getYear gives us years since UNIX epoch, while getYear expects a full year
-  next.setMonth(now.getMonth())
-  next.setDate(now.getDate()-1); // Yesterday to make sure the new moment is in the past
-  
+  next.setFullYear(now.getFullYear()); // add 1900 because getYear gives us years since UNIX epoch, while getYear expects a full year
+  next.setMonth(now.getMonth());
+  next.setDate(now.getDate() - 1); // Yesterday to make sure the new moment is in the past
+
   let limit = 10;
   // Keep moving forward by 12 hours until we reach a restart that hasn't occured yet
   while (next < now) {
     next.setTime(next.getTime() + 1000 * 60 * 60 * 12);
     limit -= 1;
-    if(limit == 0){
+    if (limit <= 0) {
       throw "Something's wrong with the restart time calculation!";
     }
   }
-  
+
   let diff = next.getTime() - now.getTime();
   let seconds = (diff / 1000);
   let minutes = seconds / 60;
   let hours = minutes / 60;
-  
+
   seconds = seconds % 60;
   minutes = minutes % 60;
-  
+
   seconds = Math.floor(seconds);
   minutes = Math.floor(minutes);
   hours = Math.floor(hours);
 
-  if(hours > 0){
+  if (hours > 0) {
     msg.channel.send(`The next restart is in ${hours}:${minutes}:${seconds}`);
     return;
   }
-  if(minutes > 0){
+  if (minutes > 0) {
     msg.channel.send(`The next restart is in ${minutes}:${seconds}`);
     return;
   }
-  if(seconds > 0){
+  if (seconds > 0) {
     msg.channel.send(`The next restart is in ${seconds} seconds!!!`);
     return;
   }
   throw "Something's wrong with the restart time calculations";
 }
+
 module.exports.serverStatus = serverStatus;
 module.exports.restartTime = restartTime;

--- a/bot/commands/server.js
+++ b/bot/commands/server.js
@@ -1,7 +1,7 @@
 const ms = require("../lib/minestat");
 const settings = require('../lib/options')('server');
 
-settings.set('showPlayercount',false);
+settings.define('showPlayercount','boolean', false);
 
 var serverStatus_options = {
     "pcmode": {name:"Show playercount", type: 'bool', value: false}

--- a/bot/commands/server.js
+++ b/bot/commands/server.js
@@ -1,42 +1,50 @@
 const ms = require("../lib/minestat");
+const settings = require('../lib/options')('server');
 
-function serverStatus(msg, args, command, client) {
-    ms.init('198.50.141.83', 25565, function (result) {
-        console.log("Minecraft server status of " + ms.address + " on port " + ms.port + ":");
-        if (ms.online) {
-            msg.channel.send({
-                "embed": {
-                    "url": "https://discordapp.com",
-                    "color": 1234643,
-                    "thumbnail": {
-                        "url": "https://api.minetools.eu/favicon/198.50.141.83/25565"
-                    },
-                    "author": {
-                        "name": "SwancraftMC",
-                        "url": "https://www.swancraftmc.com/"
-                    },
-                    "fields": [
-                        {
-                            "name": "Server status",
-                            "value": "Online ✓"
-                        },
-                        {
-                            "name": "Server IP",
-                            "value": "play.swancraftmc.com"
-                        },
-                        {
-                            "name": "Server version",
-                            "value": ms.version
-                        }
-                    ]
-                }
-            });
-        }
-        else {
-            msg.channel.send("Server is offline. Please try again later.");
-        }
-    });
+settings.set('showPlayercount',false);
+
+var serverStatus_options = {
+    "pcmode": {name:"Show playercount", type: 'bool', value: false}
 };
+async function serverStatus(msg, args, command, client) {
+    let result = await new Promise(resolve => ms.init('198.50.141.83',25565, (a) => resolve(a)));
+    if (!ms.online) {
+        msg.channel.send("Server is offline. Please try again later.");
+        return;
+    }
+    let message = {
+        "embed": {
+            "url": "https://discordapp.com",
+            "color": 1234643,
+            "thumbnail": {
+                "url": "https://api.minetools.eu/favicon/198.50.141.83/25565"
+            },
+            "author": {
+                "name": "SwancraftMC",
+                "url": "https://www.swancraftmc.com/"
+            },
+            "fields": [
+                {
+                    "name": "Server status",
+                    "value": "Online ✓"
+                },
+                {
+                    "name": "Server IP",
+                    "value": "play.swancraftmc.com"
+                },
+                {
+                    "name": "Server version",
+                    "value": ms.version
+                }
+            ]
+        }
+    };
+    console.log(settings.get("showPlayercount"));
+    if(settings.get('showPlayercount')){
+        message.embed.fields.push({name: "Players online", value:ms.current_players})
+    }
+    msg.channel.send(message);
+}
 
 function restartTime(msg, args, command, client){
   const now = new Date();

--- a/bot/commands/vote.js
+++ b/bot/commands/vote.js
@@ -1,27 +1,27 @@
 module.exports = (msg, args, command, client) => {
-    msg.channel.send(
-        //change from here
-        {
-            "embed": {
-                "color": 1234643,
-                "author": {
-                    "name": "SwancraftMC Voting",
-                    "url": "https://www.swancraftmc.com/vote"
-                },
-                "fields": [
-                    {
-                        "name": "Vote links",
-                        "value": "[Planet Minecraft](https://planetminecraft.com/server/swancraft-3882768/vote/)\n" +
-                        "[Minecraft Servers](http://minecraftservers.org/vote/410424)\n" +
-                        "[Minecraft Server List](http://minecraft-server-list.com/server/389267/vote/)\n" +
-                        "[TopG](http://topg.org/Minecraft/in-449700)\n" +
-                        "[Minecraft-Server](https://goo.gl/VeyXyQ)\n" +
-                        "[Minecraft MP](http://minecraft-mp.com/server/145239/vote/)\n" +
-                        "[Minecraft Forum](https://minecraftservers.biz/servers/73758/)"
-                    }
-                ]
-            }
-        }
-        //to here if you add more vote links
-    )
+  msg.channel.send(
+    //change from here
+    {
+      "embed": {
+        "color": 1234643,
+        "author": {
+          "name": "SwancraftMC Voting",
+          "url": "https://www.swancraftmc.com/vote"
+        },
+        "fields": [
+          {
+            "name": "Vote links",
+            "value": "[Planet Minecraft](https://planetminecraft.com/server/swancraft-3882768/vote/)\n" +
+              "[Minecraft Servers](http://minecraftservers.org/vote/410424)\n" +
+              "[Minecraft Server List](http://minecraft-server-list.com/server/389267/vote/)\n" +
+              "[TopG](http://topg.org/Minecraft/in-449700)\n" +
+              "[Minecraft-Server](https://goo.gl/VeyXyQ)\n" +
+              "[Minecraft MP](http://minecraft-mp.com/server/145239/vote/)\n" +
+              "[Minecraft Forum](https://minecraftservers.biz/servers/73758/)"
+          }
+        ]
+      }
+    }
+    //to here if you add more vote links
+  )
 };

--- a/bot/lib/browser-extension.js
+++ b/bot/lib/browser-extension.js
@@ -4,67 +4,67 @@ const tableSource = new EnmapLevel({name: "News"});
 const myTable = new Enmap({provider: tableSource});
 
 const express = require('express');
-var app = express();
+const app = express();
 
 var apiKeys = [];
 
 app.use(express.json());
-app.use(function(req, res, next) {
-    res.header('Access-Control-Allow-Origin', req.get('Origin') || '*');
-    res.header('Access-Control-Allow-Credentials', 'true');
-    res.header('Access-Control-Allow-Methods', 'GET,HEAD,PUT,POST,PATCH,POST,DELETE');
-    res.header('Access-Control-Expose-Headers', 'Content-Length');
-    res.header('Access-Control-Allow-Headers', 'Accept, Authorization, Content-Type, X-Requested-With, Range');
-    if (req.method === 'OPTIONS') {
-        return res.sendStatus(200);
-    } else {
-        return next();
-    }
+app.use(function (req, res, next) {
+  res.header('Access-Control-Allow-Origin', req.get('Origin') || '*');
+  res.header('Access-Control-Allow-Credentials', 'true');
+  res.header('Access-Control-Allow-Methods', 'GET,HEAD,PUT,POST,PATCH,POST,DELETE');
+  res.header('Access-Control-Expose-Headers', 'Content-Length');
+  res.header('Access-Control-Allow-Headers', 'Accept, Authorization, Content-Type, X-Requested-With, Range');
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(200);
+  } else {
+    return next();
+  }
 });
 
-app.get("/heartbeat", function(request, response){
-    response.send(JSON.stringify({
-        "APIversion": 1
-    }));
+app.get("/heartbeat", function (request, response) {
+  response.send(JSON.stringify({
+    "APIversion": 1
+  }));
 });
 
-app.post("/submitPosts", function(request, response){
-    console.log("Request came in");
-    if(request.body.API_KEY === undefined){
-        response.status(401).json({
-            code:"MISSING_API_KEY",
-            message:"Request does not specify an API_KEY, will not accept data without one"
-        });
-        return;
-    }
-    if(request.body.posts === undefined){
-        response.status(401).json({
-            code:"MISSING_POSTS",
-            message:"Request does not contain a list on posts under 'posts'"
-        });
-        return;
-    }
+app.post("/submitPosts", function (request, response) {
+  console.log("Request came in");
+  if (request.body.API_KEY === undefined) {
+    response.status(401).json({
+      code: "MISSING_API_KEY",
+      message: "Request does not specify an API_KEY, will not accept data without one"
+    });
+    return;
+  }
+  if (request.body.posts === undefined) {
+    response.status(401).json({
+      code: "MISSING_POSTS",
+      message: "Request does not contain a list on posts under 'posts'"
+    });
+    return;
+  }
 
-    // TODO: More precise checks
-    let key = request.body.API_KEY;
-    let valid = apiKeys.includes(key);
-    if(!valid){
-        response.status(401).json({
-            code:"BAD_API_TOKEN",
-            message:"The API key provided is invalid or has been revoked"
-        });
-        return;
-    }
+  // TODO: More precise checks
+  let key = request.body.API_KEY;
+  let valid = apiKeys.includes(key);
+  if (!valid) {
+    response.status(401).json({
+      code: "BAD_API_TOKEN",
+      message: "The API key provided is invalid or has been revoked"
+    });
+    return;
+  }
 
-    
-    let posts = request.body.posts;
 
-    // Important note: enmap-level saves as string, and will only automatically parse arrays and objects
-    myTable.set("lastVolunteerKey", key); // string
-    myTable.set("posts", posts); // array
-    myTable.set("date", new Date().getTime()); // Number, becomes a string
+  let posts = request.body.posts;
 
-    response.status(200).json(posts);
+  // Important note: enmap-level saves as string, and will only automatically parse arrays and objects
+  myTable.set("lastVolunteerKey", key); // string
+  myTable.set("posts", posts); // array
+  myTable.set("date", new Date().getTime()); // Number, becomes a string
+
+  response.status(200).json(posts);
 });
 
 /**
@@ -85,16 +85,15 @@ module.exports.revokeApiKey = (val) => apiKeys = apiKeys.filter(i => i !== val);
  */
 module.exports.app = app;
 
-module.exports.getPosts = function(){
-    return myTable.get("posts");
+module.exports.getPosts = function () {
+  return myTable.get("posts");
 };
 
-module.exports.getBlame = function(){
-    return myTable.get("lastVolunteerKey");
+module.exports.getBlame = function () {
+  return myTable.get("lastVolunteerKey");
 };
-module.exports.getBlameDate = function(){
-    // Stored as a number converted to a string
-    let value = myTable.get("date");
-    let date = new Date(Number(value));
-    return date;
+module.exports.getBlameDate = function () {
+  // Stored as a number converted to a string
+  let value = myTable.get("date");
+  return new Date(Number(value));
 };

--- a/bot/lib/options.js
+++ b/bot/lib/options.js
@@ -1,5 +1,10 @@
 var namespaces = {};
 
+var filters = {
+    'boolean': (val) => {if(typeof val !== 'boolean') throw 'Value must be boolean'; return val},
+    'numeric':  (val) => {if(typeof val !== 'number') throw 'Value must be a number'; return val},
+    'string':  (val) => {if(typeof val === 'string') throw 'Value must be a string'; return val},
+};
 
 function getOptionsManager(namespace){
     if(namespaces[namespace] !== undefined){
@@ -7,8 +12,33 @@ function getOptionsManager(namespace){
     }
     var options = {};
     let closure = {
-        set: (name, val) => { options[name] = val;},
-        get: (name) => options[name],
+        define: (name, type, value) => {
+            let filter = filters[type];
+            filter(value); // Test if valid
+            options[name.toLowerCase()] = {type: type, val:value, filters:[]};
+        },
+
+        addFilter: (name, check, errorMessage) => options[name].filters.push((val) => {
+            if(!check){
+                throw errorMessage;
+            }
+        }),
+
+        set: (name, val) => {
+            name = name.toLowerCase();
+            if(options[name] === undefined){
+                throw "Option must be defined first";
+            }
+            filters[options[name].type](val); // Check type
+            for(let check of options[name].filters){
+                check(val); // Check custom filters
+            }
+            options[name].val = val;
+        },
+
+        get: (name) => options[name.toLowerCase()].val,
+        type: (name) => options[name.toLowerCase()].type,
+
         list: () => Object.keys(options)
     };
     namespaces[namespace] = closure;
@@ -16,4 +46,49 @@ function getOptionsManager(namespace){
 }
 
 module.exports = getOptionsManager;
-module.exports.all = namespaces;
+module.exports.all = () => Object.keys(namespaces);
+
+// Create an express app if express is installed
+try {
+    const express = require('express');
+    let app = new express();
+    app.use(express.json());
+
+    function sendError(error, response){
+        response.status(500);
+        response.contentType("text/plain");
+        response.send(error.toString());
+        response.end();
+        return true;
+    }
+    app.put('/:namespace/:option', (req, res) => {
+        let newval = req.body.value;
+        let optionName = req.params.option;
+        let options = getOptionsManager(req.params.namespace);
+        try{
+            options.set(optionName, newval);
+        } catch (e) {
+            return sendError(e, res);
+        }
+        res.contentType("application/json");
+        res.send(options.get(optionName));
+    });
+    app.get('/:namespace/:option', (req, res) => {
+        res.contentType("application/json");
+        res.send(getOptionsManager(req.params.namespace).get(req.params.option));
+    });
+    app.get('/', (req, res) => {
+        let object = {};
+        for(let ns of module.exports.all()){
+            object[ns] = {};
+            for(let cmd of getOptionsManager(ns).list()){
+                object[ns][cmd] = {value: getOptionsManager(ns).get(cmd), type: getOptionsManager(ns).type(cmd)};
+            }
+        }
+        res.contentType("application/json");
+        res.send(object);
+    });
+    module.exports.express = app;
+} catch(e) {
+    module.exports.express = "express is not installed";
+}

--- a/bot/lib/options.js
+++ b/bot/lib/options.js
@@ -2,8 +2,8 @@ var namespaces = {};
 
 var filters = {
     'boolean': (val) => {if(typeof val !== 'boolean') throw 'Value must be boolean'; return val},
-    'numeric':  (val) => {if(typeof val !== 'number') throw 'Value must be a number'; return val},
-    'string':  (val) => {if(typeof val === 'string') throw 'Value must be a string'; return val},
+    'number':  (val) => {if(typeof val !== 'number') throw 'Value must be a number'; return val},
+    'string':  (val) => {if(typeof val !== 'string') throw 'Value must be a string'; return val},
 };
 
 function getOptionsManager(namespace){
@@ -71,7 +71,7 @@ try {
             return sendError(e, res);
         }
         res.contentType("application/json");
-        res.send(options.get(optionName));
+        res.send(200, options.get(optionName));
     });
     app.get('/:namespace/:option', (req, res) => {
         res.contentType("application/json");

--- a/bot/lib/options.js
+++ b/bot/lib/options.js
@@ -7,59 +7,68 @@ let isReady = myTable.fetchEverything(); // Extremely important, three hours wer
 var namespaces = {};
 
 var filters = {
-    'boolean': (val) => {if(typeof val !== 'boolean') throw 'Value must be boolean'; return val},
-    'number':  (val) => {if(typeof val !== 'number') throw 'Value must be a number'; return val},
-    'string':  (val) => {if(typeof val !== 'string') throw 'Value must be a string'; return val},
+  'boolean': (val) => {
+    if (typeof val !== 'boolean') throw 'Value must be boolean';
+    return val
+  },
+  'number': (val) => {
+    if (typeof val !== 'number') throw 'Value must be a number';
+    return val
+  },
+  'string': (val) => {
+    if (typeof val !== 'string') throw 'Value must be a string';
+    return val
+  },
 };
 
-function getOptionsManager(namespace){
-    if(namespaces[namespace] !== undefined){
-        return namespaces[namespace];
-    }
-    var options = {};
-    let closure = {
-      define: async (name, type, value) => {
-            await isReady; // Extremely important
-            name = name.toLowerCase();
-            let filter = filters[type];
-            filter(value); // Test if valid
+function getOptionsManager(namespace) {
+  if (namespaces[namespace] !== undefined) {
+    return namespaces[namespace];
+  }
+  var options = {};
+  let closure = {
+    define: async (name, type, value) => {
+      await isReady; // Extremely important
+      name = name.toLowerCase();
+      let filter = filters[type];
+      filter(value); // Test if valid
 
-            if(!myTable.has(namespace)){
-              myTable.set(namespace, {});
-            }
+      if (!myTable.has(namespace)) {
+        myTable.set(namespace, {});
+      }
 
-            if(!myTable.hasProp(namespace, name)){
-              myTable.setProp(namespace, name, value);
-            }
+      if (!myTable.hasProp(namespace, name)) {
+        myTable.setProp(namespace, name, value);
+      }
 
-            options[name] = {type: type, filters:[]};
-        },
+      options[name] = {type: type, filters: []};
+    },
 
-        addFilter: (name, check, errorMessage) => options[name].filters.push((val) => {
-            if(!check(val)){
-                throw errorMessage;
-            }
-        }),
+    addFilter: (name, check, errorMessage) => options[name].filters.push((val) => {
+      if (!check(val)) {
+        throw errorMessage;
+      }
+    }),
 
-        set: (name, val) => {
-            name = name.toLowerCase();
-            if(options[name] === undefined){
-                throw "Option must be defined first";
-            }
-            filters[options[name].type](val); // Check type
-            for(let check of options[name].filters){
-                check(val); // Check custom filters
-            }
-            myTable.setProp(namespace, name, val);
-        },
+    set: (name, val) => {
+      name = name.toLowerCase();
+      if (options[name] === undefined) {
+        throw "Option must be defined first";
+      }
+      filters[options[name].type](val); // Check type
+      for (let check of options[name].filters) {
+        check(val); // Check custom filters
+      }
+      myTable.setProp(namespace, name, val);
+    },
 
-        get: (name) => myTable.getProp(namespace, name.toLowerCase()),
-        type: (name) => options[name.toLowerCase()].type,
+    get: (name) => myTable.getProp(namespace, name.toLowerCase()),
+    type: (name) => options[name.toLowerCase()].type,
 
-        list: () => Object.keys(options)
-    };
-    namespaces[namespace] = closure;
-    return closure
+    list: () => Object.keys(options)
+  };
+  namespaces[namespace] = closure;
+  return closure
 }
 
 module.exports = getOptionsManager;
@@ -67,45 +76,46 @@ module.exports.all = () => Object.keys(namespaces);
 
 // Create an express app if express is installed
 try {
-    const express = require('express');
-    let app = new express();
-    app.use(express.json());
+  const express = require('express');
+  let app = new express();
+  app.use(express.json());
 
-    function sendError(error, response){
-        response.status(500);
-        response.contentType("text/plain");
-        response.send(error.toString());
-        response.end();
-        return true;
+  function sendError(error, response) {
+    response.status(500);
+    response.contentType("text/plain");
+    response.send(error.toString());
+    response.end();
+    return true;
+  }
+
+  app.put('/:namespace/:option', (req, res) => {
+    let newval = req.body.value;
+    let optionName = req.params.option;
+    let options = getOptionsManager(req.params.namespace);
+    try {
+      options.set(optionName, newval);
+    } catch (e) {
+      return sendError(e, res);
     }
-    app.put('/:namespace/:option', (req, res) => {
-        let newval = req.body.value;
-        let optionName = req.params.option;
-        let options = getOptionsManager(req.params.namespace);
-        try{
-            options.set(optionName, newval);
-        } catch (e) {
-            return sendError(e, res);
-        }
-        res.contentType("application/json");
-        res.send(200, options.get(optionName));
-    });
-    app.get('/:namespace/:option', (req, res) => {
-        res.contentType("application/json");
-        res.send(getOptionsManager(req.params.namespace).get(req.params.option));
-    });
-    app.get('/', (req, res) => {
-        let object = {};
-        for(let ns of module.exports.all()){
-            object[ns] = {};
-            for(let cmd of getOptionsManager(ns).list()){
-                object[ns][cmd] = {value: getOptionsManager(ns).get(cmd), type: getOptionsManager(ns).type(cmd)};
-            }
-        }
-        res.contentType("application/json");
-        res.send(object);
-    });
-    module.exports.express = app;
-} catch(e) {
-    module.exports.express = "express is not installed";
+    res.contentType("application/json");
+    res.send(200, options.get(optionName));
+  });
+  app.get('/:namespace/:option', (req, res) => {
+    res.contentType("application/json");
+    res.send(getOptionsManager(req.params.namespace).get(req.params.option));
+  });
+  app.get('/', (req, res) => {
+    let object = {};
+    for (let ns of module.exports.all()) {
+      object[ns] = {};
+      for (let cmd of getOptionsManager(ns).list()) {
+        object[ns][cmd] = {value: getOptionsManager(ns).get(cmd), type: getOptionsManager(ns).type(cmd)};
+      }
+    }
+    res.contentType("application/json");
+    res.send(object);
+  });
+  module.exports.express = app;
+} catch (e) {
+  module.exports.express = "express is not installed";
 }

--- a/bot/lib/options.js
+++ b/bot/lib/options.js
@@ -1,0 +1,19 @@
+var namespaces = {};
+
+
+function getOptionsManager(namespace){
+    if(namespaces[namespace] !== undefined){
+        return namespaces[namespace];
+    }
+    var options = {};
+    let closure = {
+        set: (name, val) => { options[name] = val;},
+        get: (name) => options[name],
+        list: () => Object.keys(options)
+    };
+    namespaces[namespace] = closure;
+    return closure
+}
+
+module.exports = getOptionsManager;
+module.exports.all = namespaces;

--- a/bot/static_html/dashboard.css
+++ b/bot/static_html/dashboard.css
@@ -1,0 +1,32 @@
+body {
+    background-color: snow;
+}
+.error {color: red;}
+.success {color:green;}
+.container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.container > button {
+    margin: 1em;
+}
+
+.master {
+    flex-direction: row;
+}
+
+.sub {
+    flex-direction: column;
+    flex-wrap: nowrap;
+    margin: 2em;
+    padding: 1em;
+    background-color: white;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+    transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
+}
+
+.sub:hover {
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
+}

--- a/bot/static_html/dashboard.html
+++ b/bot/static_html/dashboard.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>Title</title>
+        <link href="dashboard.css" rel="stylesheet"/>
+
+        <template id="booleanOption">
+            <input type="checkbox" class="value"/> <label class="text"></label>
+        </template>
+        <template id="numberOption">
+            <input type="number" class="value"/> <label class="text"></label>
+        </template>
+        <template id="stringOption">
+            <input type="text" class="value"/> <label class="text"></label>
+        </template>
+    </head>
+
+    <body>
+        <div class="container master">
+
+        </div>
+        <div class="container">
+            <button onclick="save();">Save</button>
+            <p id="error-success"></p>
+        </div>
+
+    </body>
+
+    <script src="dashboard.js"></script>
+</html>

--- a/bot/static_html/dashboard.js
+++ b/bot/static_html/dashboard.js
@@ -1,0 +1,100 @@
+const API_BASE = "/options";
+
+function createOption(type, value, text, update) {
+  let template = document.getElementById(type + "Option");
+
+  let line = document.createElement("div");
+  line.appendChild(document.importNode(template.content, true));
+
+  let input = line.querySelector(".value");
+  let textElement = line.querySelector(".text");
+
+  let getValue = () => {
+    switch(type){
+      case 'boolean': return input.checked;
+      case 'number': return Number(input.value);
+      case 'string': return input.value;
+      default:
+        console.warn("Unknown type ",type,", loading by value anyway");
+        return input.value
+    }
+  }
+  let setValue = type === 'boolean' ? (val) => input.checked = val : (val) => input.value = val;
+
+  textElement.innerText = text;
+  setValue(value);
+
+  line.querySelector(".value").onchange = (e) => update(getValue());
+  return line;
+}
+
+var data;
+fetch("/options")
+  .then(res => res.json())
+  .then(namespaces => {
+    data = namespaces;
+    let $container = document.getElementsByClassName("container")[0];
+    for (let ns of Object.keys(namespaces)) {
+      let $namespace = document.createElement("div");
+      $namespace.classList.add("container");
+      $namespace.classList.add("sub");
+      let $label = document.createElement("h1");
+      $label.textContent = ns;
+      $namespace.appendChild($label);
+      for (let option of Object.keys(namespaces[ns])) {
+        console.log(namespaces[ns][option]);
+        $namespace.appendChild(createOption(namespaces[ns][option].type, namespaces[ns][option].value, option, (val) => {
+          namespaces[ns][option].newvalue = val
+        }))
+      }
+      $container.appendChild($namespace);
+    }
+  });
+
+async function save() {
+  let promises = [];
+  for (let ns of Object.keys(data)) {
+    for (let option of Object.keys(data[ns])) {
+      let newVal = data[ns][option].newvalue;
+      let oldVal = data[ns][option].value;
+
+      console.log(data, ns, option);
+      if (newVal === undefined) continue;
+
+      if (newVal !== oldVal) {
+        promises.push(updateValue(ns, option, newVal));
+      }
+    }
+  }
+  if(promises.length === 0){
+    return
+  }
+
+  let errSucc = document.getElementById("error-success");
+  try {
+    let resolved = await Promise.all(promises);
+    errSucc.classList.remove("error");
+    errSucc.classList.add("success");
+    errSucc.textContent = "Successfully updated "+resolved.length+" options";
+  } catch(e) {
+    console.error(e);
+    errSucc.classList.add("error");
+    errSucc.classList.remove("success");
+    errSucc.textContent = "Failed to save one or more of "+resolved.length+" options";
+    return;
+  }
+  await sleep(1000);
+  window.location.reload();
+}
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+function updateValue(ns, option, newVal) {
+  return fetch(`${API_BASE}/${ns}/${option}`,{
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({value: newVal}), // body data type must match "Content-Type" header
+  })
+}


### PR DESCRIPTION
* Example setting implemented for the !server command
to toggle whether it shows playercount or not (Resolves #3)

New library 'options' keeps track of all created options and ensures duplicates aren't accidentally created
```
const Options = require('../lib/options)
let s1 = Options('server')
let s2 = Options('server')
s1.set("showPlayercount", 'boolean', false);
s2.get("showPlayercount"); // true, because s1 and s2 are the same object - this works even across different files
```
command 'options' enables listing all the options, as well as changing them from discord

Potential improvements:
* Persist options to a file so they are not reset every time the bot is restarted
* Ability to mark specific commands as using specific options (currently options just.. exist)